### PR TITLE
Add specs for the Vanguard adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+/spec/request_cache
+/.env
+/log/

--- a/fine_ants.gemspec
+++ b/fine_ants.gemspec
@@ -24,4 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "pry"
+
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "puffing-billy"
+  spec.add_development_dependency "poltergeist"
+  spec.add_development_dependency "dotenv"
 end

--- a/lib/fine_ants/adapters/vanguard.rb
+++ b/lib/fine_ants/adapters/vanguard.rb
@@ -3,6 +3,8 @@ require "bigdecimal"
 module FineAnts
   module Adapters
     class Vanguard
+      include Capybara::DSL
+
       def initialize(credentials)
         @user = credentials[:user]
         @password = credentials[:password]

--- a/spec/fine_ants/adapters/vanguard_spec.rb
+++ b/spec/fine_ants/adapters/vanguard_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+def required_value(adapter_name, env_key)
+  # TODO: Add validation? Add a regex as an optional argument?
+  return ENV[env_key] unless ENV[env_key].nil?
+  puts <<-TEXT.gsub(/^\s+/,'')
+    To run the specs for the #{adapter_name} adapter, a valid value is required
+    for #{env_key}.
+    It can be set in .env or as an ENV variable on the command line.
+    Or you may enter the value for #{env_key} here:
+  TEXT
+  gets.chomp
+end
+
+RSpec.describe FineAnts::Adapters::Vanguard do
+  let(:adapter) { FineAnts::Adapters::Vanguard.new(credentials) }
+
+  context "invalid credentials" do
+    let(:credentials) { Hash[user: 'foo', password: 'bar'] }
+
+    describe "#login" do
+      it "raises a FineAnts::LoginFailedError exception" do
+        expect{adapter.login}.to raise_exception(FineAnts::LoginFailedError)
+      end
+    end
+  end
+
+  context "valid credentials" do
+    let(:valid_user) { required_value('Vanguard', 'VANGUARD_USER') }
+    let(:valid_password) { required_value('Vanguard', 'VANGUARD_PASSWORD') }
+
+    let(:credentials) { Hash[user: valid_user, password: valid_password] }
+
+    # NOTE: We really want to test login with two_factor_response
+    # This suggests that the IO logic in FineAnts::Runner#login! should be moved to the adapter
+    describe "#login" do
+      it "returns true" do
+        runner = FineAnts::Runner.new(adapter, credentials)
+        runner.send(:login!)
+        # If the previous line does not raise an exception, then we successfully logged in.
+        # So there is no assertion needed for this spec.
+      end
+    end
+
+    describe "#download" do
+      it "does what it is supposed to" do
+        skip
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'dotenv'
+Dotenv.load
+
+require "fine_ants"
+require 'support/capybara_helper'

--- a/spec/support/capybara_helper.rb
+++ b/spec/support/capybara_helper.rb
@@ -1,0 +1,32 @@
+require 'capybara/poltergeist'
+require 'support/monkeypatch_poltergeist'
+
+Billy.configure do |c|
+  c.cache = true
+  c.logger = Logger.new("log/test.log")
+  # c.ignore_params = [
+  #   "http://www.google-analytics.com/__utm.gif",
+  # ]
+
+  c.persist_cache = true
+  c.non_successful_cache_disabled = false
+  c.non_successful_error_level = :warn
+  c.cache_request_headers = false
+  c.cache_path = 'spec/request_cache/' # This path must be listed in .gitignore, to ensure private requests are not committed.
+end
+
+Capybara.configure do |config|
+  config.run_server = true
+
+  # :selenium_chrome_billy works but it opens a browser
+  # :poltergeist_billy seems to work well, and is headless
+  # There is this note on puffing-billy's README:
+    # Note: :poltergeist_billy doesn't support proxying any localhosts, so you must
+    # use :webkit_billy for headless specs when using puffing-billy for other local
+    # rack apps. See this phantomjs issue for any updates.
+  config.default_driver = :poltergeist_billy
+  config.app = 'fake app name'
+end
+
+server = Capybara.current_session.server
+Billy.config.whitelist = ["#{server.host}:#{server.port}"]

--- a/spec/support/monkeypatch_poltergeist.rb
+++ b/spec/support/monkeypatch_poltergeist.rb
@@ -1,0 +1,29 @@
+# The next line is the usual require. But this file does the same thing, with a monkeypatch.
+# require 'billy/capybara/rspec'
+
+# Monkeypatch the poltergeist driver to not complain about js errors
+require 'capybara/rspec'
+require 'billy/browsers/capybara'
+require 'billy/init/rspec'
+module Billy
+  module Browsers
+    class Capybara
+      private
+
+      def self.register_poltergeist_driver
+        ::Capybara.register_driver :poltergeist_billy do |app|
+          options = {
+            phantomjs_options: [
+              '--ignore-ssl-errors=yes',
+              "--proxy=#{Billy.proxy.host}:#{Billy.proxy.port}"
+            ],
+            # TODO: Submit a PR to puffing-billy to allow passing in options, so we can eliminate this monkey patch.
+            js_errors: false,
+          }
+          ::Capybara::Poltergeist::Driver.new(app, options)
+        end
+      end
+    end
+  end
+end
+Billy::Browsers::Capybara.register_drivers


### PR DESCRIPTION
If you want to keep this as a personal gem, that's cool. Feel free to close this PR.

That said... I was playing with fine-ants tonight. I wanted two new things:
1) specs, so I could add a feature and ensure it works
2) a way to cache responses, so I could experiment in the specs without making too many requests to Vanguard and getting blocked.

I used rspec (although I can convert it to minitest if you prefer) and the [puffing billy](https://github.com/oesmith/puffing-billy) gem for vcr-like recording of browser requests.

This PR is still messier than I'd like. The two main issues I have are:
1) having Runner.login! as a private method makes it hard to test the login flow with two factor auth
2) the monkey patch to puffing billy is ugly

Also, I'm not sure where the call to "include Capybara::DSL" belongs.
