### PR TITLE
Add method to download transactions from Vanguard

### DIFF
--- a/lib/fine_ants/adapters/vanguard.rb
+++ b/lib/fine_ants/adapters/vanguard.rb
@@ -29,10 +29,12 @@ module FineAnts
         verify_login!
       end
 
+      # TODO: Rename this to be more explicit about what is being downloaded?
       def download
         rows = find(:id, "BalancesTabBoxId:balancesForm:balancesTable").all("tr")
         rows[0..-3].map do |row|
           cells = row.all("td")
+          # TODO: Extract this into a class?
           {
             :adapter => :vanguard,
             :user => @user,
@@ -41,6 +43,34 @@ module FineAnts
             :amount => BigDecimal.new(cells[1].text.match(/\$(.*)$/)[1].gsub(/,/,''))
           }
         end
+      end
+
+      def download_transactions
+        # Go to the "Download account information" page
+        visit "https://personal.vanguard.com/us/OfxWelcome"
+
+        # Select the download format: "Quicken: All funds to a single account"
+        find(:id, 'OfxDownloadForm:downloadOption_main').click
+        find(:id, 'menu-OfxDownloadForm:downloadOption').find('td', :value => 'SingleQuicken').click
+
+        # Select date range: 1 month
+        # TODO: Allow a date range to be passed in, and find the smallest option
+        # which provides the data requested.
+        # An app which uses this gem would probably store the last time a successful
+        # request was made, and request all activity since that time.
+        # Since we are currently only handling the default date range, we do not need
+        # to click on anything, so the next line is commented out.
+        # find(:id, 'OfxDownloadForm:ofxDateFilterSelectOneMenu_main').click
+
+        # Select the account(s) to download
+        # By default, download all accounts
+        find(:id, 'OfxDownloadForm:accountsTable').find(id: 'OfxDownloadForm:selectOrDeselect').click
+
+        # Click on the download button
+        find(:id, 'OfxDownloadForm:downloadButtonInput').click
+
+        puts page.response_headers
+
       end
 
     private

--- a/spec/fine_ants/adapters/vanguard_spec.rb
+++ b/spec/fine_ants/adapters/vanguard_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe FineAnts::Adapters::Vanguard do
+  let(:adapter) { FineAnts::Adapters::Vanguard.new(credentials) }
+
+  context "valid credentials" do
+    let(:valid_user) { required_value('Vanguard', 'VANGUARD_USER') }
+    let(:valid_password) { required_value('Vanguard', 'VANGUARD_PASSWORD') }
+
+    let(:credentials) { Hash[user: valid_user, password: valid_password] }
+
+    describe "#download_transactions" do
+      before do
+        runner = FineAnts::Runner.new(adapter, credentials)
+        runner.send(:login!)
+      end
+
+      it "does something with a downloaded file..." do
+        file = adapter.download_transactions
+        # TODO: Add expectation on file type or contents. Maybe high-level format?
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a rough first pass at adding a method to the Vanguard adapter which downloads the OFX file of transactions.

I can clean it up, make it work, and add proper specs if this kind of feature is something you want in the gem.
