### PR TITLE
Add a Chase adapter (currently credit cards only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Right now, FineAnts ships with adapters for:
 * [Vanguard Personal Investment](https://personal.vanguard.com/us/hnwnesc/nesc/LoginPage)
 * [PNC Personal Banking](https://www.pnc.com/en/personal-banking.html)
 * [Betterment](https://www.betterment.com)
+* [Chase](https://www.chase.com)
 
 You can also implement your own adapter and pass it to `FineAnts.download`. The
 expected public contract of an adapter is:

--- a/lib/fine_ants/adapters.rb
+++ b/lib/fine_ants/adapters.rb
@@ -3,6 +3,7 @@ require "capybara/dsl"
 require "fine_ants/adapters/vanguard"
 require "fine_ants/adapters/pnc"
 require "fine_ants/adapters/betterment"
+require "fine_ants/adapters/chase"
 
 module FineAnts
   module Adapters

--- a/lib/fine_ants/adapters/chase.rb
+++ b/lib/fine_ants/adapters/chase.rb
@@ -1,0 +1,72 @@
+require "bigdecimal"
+
+module FineAnts
+  module Adapters
+    class Chase
+      def initialize(credentials)
+        @user = credentials[:user]
+        @password = credentials[:password]
+      end
+
+      def login
+        visit "https://www.chase.com"
+        fill_in "User name", :with => @user
+        fill_in "Password", :with => @password
+        click_link "Sign in"
+        verify_login!
+      end
+
+      def logout
+        click_button "Sign out"
+      end
+
+      def download
+        # Select credit card
+        find("h3", text: "CREDIT CARDS")
+          .find(:xpath, "../..")
+          .find("section")
+          .first("div")
+          .click
+
+        credit_card_table = find("table.dl-box")
+
+        balance = credit_card_table.find("#accountCurrentBalance").text
+        available_balance = credit_card_table.find("#accountAvailableCreditBalance").text
+        next_due_date = credit_card_table.find("#nextPaymentDueDate").text
+
+        accounts = [
+          {
+            :adapter => :chase,
+            :user => @user,
+            :id => find(".ACTNAME").text,
+            :name => find(".ACTNAME").text,
+            :type => :credit_card,
+            :amount => -1 * parse_currency(balance),
+            :available_amount => parse_currency(available_balance),
+            :next_due_date => parse_due_date(next_due_date)
+          }
+        ]
+
+        logout
+        accounts
+      end
+
+      private
+
+      def parse_currency(currency_string)
+        BigDecimal.new(currency_string.match(/\$(.*)$/)[1].gsub(/,/,''))
+      end
+
+      def parse_due_date(due_date_string)
+        Date.strptime(due_date_string, "%b %d, %Y")
+      end
+
+      def verify_login!
+        find '[data-attr="LOGON_DETAILS.lastLogonDetailsLabel"]'
+      rescue Capybara::ElementNotFound
+        raise FineAnts::LoginFailedError.new
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This doesn't yet handle mortgages, car payments, etc, but seems filled out enough to warrant pushing up. It also includes a number of fields that are ignored by fine-ants-app for now, but may be worthwhile in the future.

* `:amount` - The amount owed on a credit line (negative because the funds are owed)
* `:available_amount` - The total available amount of a credit line
* `:next_due_date` - The due date of the current credit payment
