### PR TITLE
Add Target REDcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Right now, FineAnts ships with adapters for:
 * [Betterment](https://www.betterment.com)
 * [Chase](https://www.chase.com)
 * [Simple](https://www.simple.com)
+* [Target REDcard](https://rcam.target.com)
 
 You can also implement your own adapter and pass it to `FineAnts.download`. The
 expected public contract of an adapter is:

--- a/lib/fine_ants/adapters.rb
+++ b/lib/fine_ants/adapters.rb
@@ -5,6 +5,7 @@ require "fine_ants/adapters/pnc"
 require "fine_ants/adapters/betterment"
 require "fine_ants/adapters/chase"
 require "fine_ants/adapters/simple"
+require "fine_ants/adapters/target"
 
 module FineAnts
   module Adapters

--- a/lib/fine_ants/adapters/target.rb
+++ b/lib/fine_ants/adapters/target.rb
@@ -1,0 +1,60 @@
+require "bigdecimal"
+
+module FineAnts
+  module Adapters
+    class Target
+      def initialize(credentials)
+        @user = credentials[:user]
+        @password = credentials[:password]
+      end
+
+      def login
+        visit "https://rcam.target.com/default.aspx"
+
+        fill_in "Login_UserName", :with => @user
+        fill_in "Login_Password", :with => @password
+        find("#Login_btnSignIn_btnSignIn").click
+
+        verify_login!
+      end
+
+      def download
+        balance = find("#AcctSummaryRCAM_AcctTbl_CrntBal").text
+        available_balance = find("#AcctSummaryRCAM_AcctTbl_CredAvail").text
+        next_due_date = find("#AcctSummaryRCAM_AcctTbl_PmtDueDt").text
+        card_number = find("#AccountAcctNum").text.delete("For your REDcard ending in: ")
+
+        [
+          {
+            :adapter => :target,
+            :user => @user,
+            :id => "REDcard #{card_number}",
+            :name => "REDcard #{card_number}",
+            :type => :credit_card,
+            :amount => -1 * parse_currency(balance),
+            :available_amount => parse_currency(available_balance),
+            :next_due_date => parse_due_date(next_due_date)
+          }
+        ]
+      end
+
+      private
+
+      def parse_currency(currency_string)
+        BigDecimal.new(currency_string.match(/\$(.*)$/)[1].delete(","))
+      end
+
+      def parse_due_date(date_string)
+        return nil if date_string == "-"
+        date_string
+      end
+
+      def verify_login!
+        find "span#DefaultPageTitle", text: "View Account Summary"
+      rescue Capybara::ElementNotFound
+        raise FineAnts::LoginFailedError.new
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
**Negative**: Target seemingly requires two-factor auth on every login using `chromedriver`.
**Positive**: It *does* load all of the data behind the two-factor auth screen, which means one can ignore it.

This doesn't implement two-factor auth. The dialog asks questions like "Last 4 digits of SSN", "Birthday", etc, so it's not just a text-messaged number. This made it complicated enough that I've left it off for now. The two-factor prompt would need to list the question so the right answer could be provided before we could have full functionality here. The only behavior that can't be accomplished is clicking "Sign Out", as it's blocked by the modal two-factor dialog. 

The link is hard-coded to Target's REDcard site. I'm not aware of other accounts/bills that would be under the Target name, so I left the plugin as `target`, but I can rename if that's important.