### PR TITLE
Move Simple adapter over to BBVA

### DIFF
--- a/lib/fine_ants/adapters/simple.rb
+++ b/lib/fine_ants/adapters/simple.rb
@@ -1,0 +1,55 @@
+require "bigdecimal"
+
+module FineAnts
+  module Adapters
+    class Simple
+      def initialize(credentials)
+        @user = credentials[:user]
+        @password = credentials[:password]
+      end
+
+      def login
+        visit "https://www.simple.com"
+        click_link "Log In"
+
+        fill_in "username", :with => @user
+        fill_in "passphrase", :with => @password
+        click_button "Sign in"
+        verify_login!
+      end
+
+      def download
+        user_name = find(".masthead-username").text
+        balance = find_all(".balances-item-value").first.text
+        available_balance = find(".balances-sts .amount").text.strip
+
+        [
+          {
+            :adapter => :simple,
+            :user => @user,
+            :id => "#{user_name}",
+            :name => "#{user_name}",
+            :amount => parse_currency(balance),
+            :available_amount => parse_currency(available_balance),
+          }
+        ].tap{ logout! }
+      end
+
+      private
+      def logout!
+        visit "https://bank.simple.com/signout"
+      end
+
+      def parse_currency(currency_string)
+        BigDecimal.new(currency_string.match(/\$?(.*)$/)[1].delete(","))
+      end
+
+      def verify_login!
+        find("h2", text: "Safe-to-Spend")
+      rescue Capybara::ElementNotFound
+        raise FineAnts::LoginFailedError.new
+      end
+    end
+  end
+end
+

--- a/lib/fine_ants/adapters/simple_bancorp.rb
+++ b/lib/fine_ants/adapters/simple_bancorp.rb
@@ -2,7 +2,7 @@ require "bigdecimal"
 
 module FineAnts
   module Adapters
-    class Simple
+    class SimpleBancorp
       def initialize(credentials)
         @user = credentials[:user]
         @password = credentials[:password]
@@ -25,7 +25,7 @@ module FineAnts
 
         [
           {
-            :adapter => :simple,
+            :adapter => :simple_bancorp,
             :user => @user,
             :id => "#{user_name}",
             :name => "#{user_name}",


### PR DESCRIPTION
In early 2014, Simple was bought by BBVA. As part of that process, Simple has been moving all accounts over from their previous backing bank Bancorp to BBVA. All new accounts are created with BBVA. Bancorp access is considered deprecated.

Unfortunately, it seems that they have two different codebases to handle the different banks. After migrating to BBVA, I found that this adapter didn't work. I've moved the previous `Simple` adapter to `SimpleBancorp` to denote that this is a different adapter than what one would expect if they had a new account. This would represent a breaking change for those still using the Simple adapter. That said, I think we should assume people are on the new bank unless told otherwise as that is what all new accounts will have and what all old accounts will migrate to in the coming months.

**Breaking Changes**
* If you had Simple set up in FineAnts previous to this, you'll need to change the plugin to `SimpleBancorp` until your account is migrated over.