### PR TITLE
Modify Chase to keep up with webpage changes

### DIFF
--- a/lib/fine_ants/adapters/chase.rb
+++ b/lib/fine_ants/adapters/chase.rb
@@ -10,6 +10,7 @@ module FineAnts
 
       def login
         visit "https://www.chase.com"
+
         within_frame(find("#logonbox")) do
           fill_in "Username", :with => @user
           fill_in "Password", :with => @password
@@ -19,6 +20,7 @@ module FineAnts
           sleep 0.1
           click_on "Sign in"
         end
+
         verify_login!
       end
 
@@ -30,15 +32,14 @@ module FineAnts
         # Select credit card
         find("h3", text: "CREDIT CARDS")
           .find(:xpath, "../..")
-          .find("section")
-          .first("div")
+          .first(".account-tile")
           .click
 
-        credit_card_table = find("table.dl-box")
+        credit_card_table = find("div.account")
 
-        balance = credit_card_table.find("#accountCurrentBalance").text
-        available_balance = credit_card_table.find("#accountAvailableCreditBalance").text
-        next_due_date = credit_card_table.find("#nextPaymentDueDate").text
+        balance = credit_card_table.find("#accountCurrentBalanceWithToolTipValue").text
+        available_balance = credit_card_table.find("#availableCreditWithTransferBalanceValue").text
+        next_due_date = credit_card_table.find("#nextPaymentDueDateValue").text
 
         accounts = [
           {
@@ -68,7 +69,7 @@ module FineAnts
       end
 
       def verify_login!
-        find '[data-attr="LOGON_DETAILS.lastLogonDetailsLabel"]'
+        find "#logonDetailsContainer"
       rescue Capybara::ElementNotFound
         raise FineAnts::LoginFailedError.new
       end


### PR DESCRIPTION
This is a first crack at updating the Chase scraper. There will almost definitely be a second, as Chase seems to flip back and forth about whether to load their login box in an iframe or in the page itself. I was only able to pull the non-iframe version once out of fifteen login attempts tonight, so this should work in the majority of cases.

I confirmed that I'm able to login and pull credit card account balances with these changes.