### PR TITLE
Only scrape data for Betterment accounts

### DIFF
--- a/lib/fine_ants/adapters/betterment.rb
+++ b/lib/fine_ants/adapters/betterment.rb
@@ -30,7 +30,9 @@ module FineAnts
       end
 
       def download
-        accounts = all(".SummaryTable-card")
+        betterment_accounts = find("h2", text: "Betterment Accounts").
+                              find(:xpath, "../..")
+        accounts = betterment_accounts.all(".SummaryTable-card")
         accounts.map do |account|
           {
             :adapter => :betterment,


### PR DESCRIPTION
I ran into an issue where external accounts that Betterment was tracking was causing the scraper to fail. We pull the ID for each account from a regex that fails on external accounts.

As this would be duplicate information anyway, this PR limits the scraper to just Betterment accounts.